### PR TITLE
Update buildozer.spec

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -117,6 +117,12 @@ android.ndk_api = 21
 # when an update is due and you just want to test/build your package
 # android.skip_update = False
 
+# (bool) If True, then automatically accept SDK license
+# agreements. This is intended for automation only. If set to False,
+# the default, you will be shown the license when first running
+# buildozer.
+android.accept_sdk_license = True
+
 # (str) Android entry point, default is ok for Kivy-based app
 #android.entrypoint = org.renpy.android.PythonActivity
 


### PR DESCRIPTION
Solving android license sdk accept skipping in command prompt, causing abort

My first pull request ,sorry if i did it wrong