### PR TITLE
CI: remove checkout step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
           name: checkout
           command: |
             git clone https://github.com/tshirtman/kivy_service_osc.git .
-            git checkout ${CIRCLECI_SHA1}
+            echo "checking out $CIRCLE_SHA1"
+            git checkout ${CIRCLE_SHA1}
+            git rev-parse HEAD
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      -run:
+      - run:
        name: checkout
        command: |
          git clone https://github.com/tshirtman/kivy_service_osc.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      -run:
+       name: checkout
+       command: |
+         git clone https://github.com/tshirtman/kivy_service_osc.git
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - buildozer-home-{{ checksum "buildozer.spec" }}
+            - buildozer-home-2-{{ checksum "buildozer.spec" }}
             # fallback to using the latest cache if no exact match is found
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           name: checkout
           command: |
             git clone https://github.com/tshirtman/kivy_service_osc.git .
-            git checkout {{ .Revision }}
+            git checkout ${CIRCLECI_SHA1}
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
           keys:
             - buildozer-home-{{ checksum "buildozer.spec" }}
             # fallback to using the latest cache if no exact match is found
-            - buildozer-home-
 
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: checkout
           command: |
-            git clone https://github.com/tshirtman/kivy_service_osc.git
+            git clone https://github.com/tshirtman/kivy_service_osc.git .
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: build
           command: |
-            buildozer android debug || echo "done"
+            buildozer android debug
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - run:
-       name: checkout
-       command: |
-         git clone https://github.com/tshirtman/kivy_service_osc.git
+          name: checkout
+          command: |
+            git clone https://github.com/tshirtman/kivy_service_osc.git
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
           name: checkout
           command: |
             git clone https://github.com/tshirtman/kivy_service_osc.git .
+            git checkout {{ .Revision }}
+
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - checkout
-
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -89,13 +89,13 @@ fullscreen = 0
 android.permissions = INTERNET
 
 # (int) Android API to use
-android.api = 28
+#android.api = 28
 
 # (int) Minimum API required. You will need to set the android.ndk.api to be as low as this value.
 #android.minapi = 21
 
 # (str) Android NDK version to use
-android.ndk = 19c
+#android.ndk = 19c
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support. 
 #android.ndk_api = 21

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -89,16 +89,16 @@ fullscreen = 0
 android.permissions = INTERNET
 
 # (int) Android API to use
-android.api = 26
+#android.api = 26
 
 # (int) Minimum API required. You will need to set the android.ndk.api to be as low as this value.
-android.minapi = 21
+#android.minapi = 21
 
 # (str) Android NDK version to use
-android.ndk = 17c
+#android.ndk = 17c
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support. 
-android.ndk_api = 21
+#android.ndk_api = 21
 
 # (bool) Use --private data storage (True) or --dir public storage (False)
 #android.private_storage = True

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -89,13 +89,13 @@ fullscreen = 0
 android.permissions = INTERNET
 
 # (int) Android API to use
-#android.api = 26
+android.api = 28
 
 # (int) Minimum API required. You will need to set the android.ndk.api to be as low as this value.
 #android.minapi = 21
 
 # (str) Android NDK version to use
-#android.ndk = 17c
+android.ndk = 19c
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support. 
 #android.ndk_api = 21


### PR DESCRIPTION
https checkout is enough, and doesn't require ssh (missing in kivy/buildozer)